### PR TITLE
Remove error colour codes for Rakudo

### DIFF
--- a/perl6/Dockerfile
+++ b/perl6/Dockerfile
@@ -11,3 +11,6 @@ COPY files/runner /home/glot/
 USER glot
 WORKDIR /home/glot/
 CMD ["/home/glot/runner"]
+
+#Remove terminal colour codes for error reporting from Rakudo compiler output
+ENV RAKUDO_ERROR_COLOR 0


### PR DESCRIPTION
The Rakudo Perl 6 compiler by default outputs terminal colour codes for error messages which doesn't look great on the glot.io website. This environment variable should remove that.
